### PR TITLE
fix(config): move on-success & on-failure hooks to job config

### DIFF
--- a/e2e/__snapshots__/example_test.snap
+++ b/e2e/__snapshots__/example_test.snap
@@ -25,10 +25,8 @@
       Paths:       []string{
         "examples",
       },
-      Before:    (*config.HookV1)(nil),
-      After:     (*config.HookV1)(nil),
-      OnSuccess: (*config.HookV1)(nil),
-      OnFailure: (*config.HookV1)(nil),
+      Before: (*config.HookV1)(nil),
+      After:  (*config.HookV1)(nil),
     },
     config.RecipeManifestV1{
       Version:     1,
@@ -37,10 +35,8 @@
       Paths:       []string{
         "/path/to/nextcloud",
       },
-      Before:    (*config.HookV1)(nil),
-      After:     (*config.HookV1)(nil),
-      OnSuccess: (*config.HookV1)(nil),
-      OnFailure: (*config.HookV1)(nil),
+      Before: (*config.HookV1)(nil),
+      After:  (*config.HookV1)(nil),
     },
     config.RecipeManifestV1{
       Version:     1,
@@ -49,10 +45,8 @@
       Paths:       []string{
         "/path/to/paperless",
       },
-      Before:    (*config.HookV1)(nil),
-      After:     (*config.HookV1)(nil),
-      OnSuccess: (*config.HookV1)(nil),
-      OnFailure: (*config.HookV1)(nil),
+      Before: (*config.HookV1)(nil),
+      After:  (*config.HookV1)(nil),
     },
   },
   MainConfig: config.MainConfig{
@@ -85,24 +79,32 @@
           "local",
           "s3",
         },
+        OnSuccess: (*config.HookV1)(nil),
+        OnFailure: (*config.HookV1)(nil),
       },
       "paperless": config.JobConfigV1{
         Recipe:   "paperless",
         BackupTo: []string{
           "s3",
         },
+        OnSuccess: (*config.HookV1)(nil),
+        OnFailure: (*config.HookV1)(nil),
       },
       "test": config.JobConfigV1{
         Recipe:   "examples",
         BackupTo: []string{
           "local",
         },
+        OnSuccess: (*config.HookV1)(nil),
+        OnFailure: (*config.HookV1)(nil),
       },
       "test-restic": config.JobConfigV1{
         Recipe:   "examples",
         BackupTo: []string{
           "local-restic",
         },
+        OnSuccess: (*config.HookV1)(nil),
+        OnFailure: (*config.HookV1)(nil),
       },
     },
     Secrets: map[string]config.SecretConfigV1{

--- a/e2e/__snapshots__/example_test.snap
+++ b/e2e/__snapshots__/example_test.snap
@@ -25,12 +25,10 @@
       Paths:       []string{
         "examples",
       },
-      Hooks: config.HooksV1{
-        Before:    (*config.HookV1)(nil),
-        After:     (*config.HookV1)(nil),
-        OnSuccess: (*config.HookV1)(nil),
-        OnFailure: (*config.HookV1)(nil),
-      },
+      Before:    (*config.HookV1)(nil),
+      After:     (*config.HookV1)(nil),
+      OnSuccess: (*config.HookV1)(nil),
+      OnFailure: (*config.HookV1)(nil),
     },
     config.RecipeManifestV1{
       Version:     1,
@@ -39,12 +37,10 @@
       Paths:       []string{
         "/path/to/nextcloud",
       },
-      Hooks: config.HooksV1{
-        Before:    (*config.HookV1)(nil),
-        After:     (*config.HookV1)(nil),
-        OnSuccess: (*config.HookV1)(nil),
-        OnFailure: (*config.HookV1)(nil),
-      },
+      Before:    (*config.HookV1)(nil),
+      After:     (*config.HookV1)(nil),
+      OnSuccess: (*config.HookV1)(nil),
+      OnFailure: (*config.HookV1)(nil),
     },
     config.RecipeManifestV1{
       Version:     1,
@@ -53,12 +49,10 @@
       Paths:       []string{
         "/path/to/paperless",
       },
-      Hooks: config.HooksV1{
-        Before:    (*config.HookV1)(nil),
-        After:     (*config.HookV1)(nil),
-        OnSuccess: (*config.HookV1)(nil),
-        OnFailure: (*config.HookV1)(nil),
-      },
+      Before:    (*config.HookV1)(nil),
+      After:     (*config.HookV1)(nil),
+      OnSuccess: (*config.HookV1)(nil),
+      OnFailure: (*config.HookV1)(nil),
     },
   },
   MainConfig: config.MainConfig{

--- a/internal/backup.go
+++ b/internal/backup.go
@@ -52,9 +52,9 @@ func (s *backupService) Backup(cfg config.Config, jobName string) error {
 
 	var errs error
 
-	if recipe.Hooks.Before != nil {
-		logger.Info("running before hook", slog.Any("hook", recipe.Hooks.Before))
-		err := runHook(*recipe.Hooks.Before)
+	if recipe.Before != nil {
+		logger.Info("running before hook", slog.Any("hook", recipe.Before))
+		err := runHook(*recipe.Before)
 		if err != nil {
 			errs = errors.Join(errs, fmt.Errorf("before hook failed: %w", err))
 		}
@@ -99,9 +99,9 @@ func (s *backupService) Backup(cfg config.Config, jobName string) error {
 		}
 	}
 
-	if recipe.Hooks.After != nil {
-		logger.Info("running after hook", slog.Any("hook", recipe.Hooks.After))
-		err := runHook(*recipe.Hooks.After)
+	if recipe.After != nil {
+		logger.Info("running after hook", slog.Any("hook", recipe.After))
+		err := runHook(*recipe.After)
 		if err != nil {
 			errs = errors.Join(errs, fmt.Errorf("after hook failed: %w", err))
 		}
@@ -109,9 +109,9 @@ func (s *backupService) Backup(cfg config.Config, jobName string) error {
 
 	if errs == nil {
 		logger.Info("completed backup", slog.Duration("duration", time.Since(startTime)))
-		if recipe.Hooks.OnSuccess != nil {
-			logger.Info("running on-success hook", slog.Any("hook", recipe.Hooks.OnSuccess))
-			err := runHook(*recipe.Hooks.OnSuccess)
+		if recipe.OnSuccess != nil {
+			logger.Info("running on-success hook", slog.Any("hook", recipe.OnSuccess))
+			err := runHook(*recipe.OnSuccess)
 			if err != nil {
 				errs = errors.Join(errs, fmt.Errorf("on-success hook failed: %w", err))
 			}
@@ -124,9 +124,9 @@ func (s *backupService) Backup(cfg config.Config, jobName string) error {
 			slog.Duration("duration", time.Since(startTime)),
 			slog.Any("error", errs),
 		)
-		if recipe.Hooks.OnFailure != nil {
-			logger.Info("running on-failure hook", slog.Any("hook", recipe.Hooks.OnFailure))
-			err := runHook(*recipe.Hooks.OnFailure)
+		if recipe.OnFailure != nil {
+			logger.Info("running on-failure hook", slog.Any("hook", recipe.OnFailure))
+			err := runHook(*recipe.OnFailure)
 			if err != nil {
 				errs = errors.Join(errs, fmt.Errorf("on-failure hook failed: %w", err))
 			}

--- a/internal/backup.go
+++ b/internal/backup.go
@@ -109,9 +109,9 @@ func (s *backupService) Backup(cfg config.Config, jobName string) error {
 
 	if errs == nil {
 		logger.Info("completed backup", slog.Duration("duration", time.Since(startTime)))
-		if recipe.OnSuccess != nil {
-			logger.Info("running on-success hook", slog.Any("hook", recipe.OnSuccess))
-			err := runHook(*recipe.OnSuccess)
+		if job.OnSuccess != nil {
+			logger.Info("running on-success hook", slog.Any("hook", job.OnSuccess))
+			err := runHook(*job.OnSuccess)
 			if err != nil {
 				errs = errors.Join(errs, fmt.Errorf("on-success hook failed: %w", err))
 			}
@@ -124,9 +124,9 @@ func (s *backupService) Backup(cfg config.Config, jobName string) error {
 			slog.Duration("duration", time.Since(startTime)),
 			slog.Any("error", errs),
 		)
-		if recipe.OnFailure != nil {
-			logger.Info("running on-failure hook", slog.Any("hook", recipe.OnFailure))
-			err := runHook(*recipe.OnFailure)
+		if job.OnFailure != nil {
+			logger.Info("running on-failure hook", slog.Any("hook", job.OnFailure))
+			err := runHook(*job.OnFailure)
 			if err != nil {
 				errs = errors.Join(errs, fmt.Errorf("on-failure hook failed: %w", err))
 			}

--- a/internal/backup_test.go
+++ b/internal/backup_test.go
@@ -127,14 +127,6 @@ func TestBackupHooksSuccess(t *testing.T) {
 					Shell:   "bash",
 					Command: fmt.Sprintf("echo after >> %s", hooksLog),
 				},
-				OnSuccess: &config.HookV1{
-					Shell:   "bash",
-					Command: fmt.Sprintf("echo on-success >> %s", hooksLog),
-				},
-				OnFailure: &config.HookV1{
-					Shell:   "bash",
-					Command: fmt.Sprintf("echo on-failure >> %s", hooksLog),
-				},
 			}},
 			MainConfig: config.MainConfig{
 				Destinations: map[string]config.DestinationConfigV1{
@@ -149,6 +141,14 @@ func TestBackupHooksSuccess(t *testing.T) {
 					"do-it": {
 						Recipe:   "r",
 						BackupTo: []string{"d1", "d2"},
+						OnSuccess: &config.HookV1{
+							Shell:   "bash",
+							Command: fmt.Sprintf("echo on-success >> %s", hooksLog),
+						},
+						OnFailure: &config.HookV1{
+							Shell:   "bash",
+							Command: fmt.Sprintf("echo on-failure >> %s", hooksLog),
+						},
 					},
 				},
 			},
@@ -198,14 +198,6 @@ func TestBackupHooksFailure(t *testing.T) {
 					Shell:   "bash",
 					Command: fmt.Sprintf("echo after >> %s", hooksLog),
 				},
-				OnSuccess: &config.HookV1{
-					Shell:   "bash",
-					Command: fmt.Sprintf("echo on-success >> %s", hooksLog),
-				},
-				OnFailure: &config.HookV1{
-					Shell:   "bash",
-					Command: fmt.Sprintf("echo on-failure >> %s", hooksLog),
-				},
 			}},
 			MainConfig: config.MainConfig{
 				Destinations: map[string]config.DestinationConfigV1{
@@ -220,6 +212,14 @@ func TestBackupHooksFailure(t *testing.T) {
 					"do-it": {
 						Recipe:   "r",
 						BackupTo: []string{"d1", "d2"},
+						OnSuccess: &config.HookV1{
+							Shell:   "bash",
+							Command: fmt.Sprintf("echo on-success >> %s", hooksLog),
+						},
+						OnFailure: &config.HookV1{
+							Shell:   "bash",
+							Command: fmt.Sprintf("echo on-failure >> %s", hooksLog),
+						},
 					},
 				},
 			},
@@ -377,10 +377,6 @@ func TestBackupOnSuccessHookError(t *testing.T) {
 		config.Config{
 			Recipes: []config.RecipeManifestV1{{
 				Name: "r",
-				OnSuccess: &config.HookV1{
-					Shell:   "bash",
-					Command: "exit 42",
-				},
 			}},
 			MainConfig: config.MainConfig{
 				Destinations: map[string]config.DestinationConfigV1{
@@ -392,6 +388,10 @@ func TestBackupOnSuccessHookError(t *testing.T) {
 					"do-it": {
 						Recipe:   "r",
 						BackupTo: []string{"bogus"},
+						OnSuccess: &config.HookV1{
+							Shell:   "bash",
+							Command: "exit 42",
+						},
 					},
 				},
 			},
@@ -419,10 +419,6 @@ func TestBackupOnFailureHookError(t *testing.T) {
 		config.Config{
 			Recipes: []config.RecipeManifestV1{{
 				Name: "r",
-				OnFailure: &config.HookV1{
-					Shell:   "bash",
-					Command: "exit 42",
-				},
 			}},
 			MainConfig: config.MainConfig{
 				Destinations: map[string]config.DestinationConfigV1{
@@ -434,6 +430,10 @@ func TestBackupOnFailureHookError(t *testing.T) {
 					"do-it": {
 						Recipe:   "r",
 						BackupTo: []string{"bogus"},
+						OnFailure: &config.HookV1{
+							Shell:   "bash",
+							Command: "exit 42",
+						},
 					},
 				},
 			},
@@ -466,14 +466,6 @@ func TestBackupBackupAndHooksError(t *testing.T) {
 					Shell:   "bash",
 					Command: "exit 43",
 				},
-				OnSuccess: &config.HookV1{
-					Shell:   "bash",
-					Command: "exit 44",
-				},
-				OnFailure: &config.HookV1{
-					Shell:   "bash",
-					Command: "exit 45",
-				},
 			}},
 			MainConfig: config.MainConfig{
 				Destinations: map[string]config.DestinationConfigV1{
@@ -485,6 +477,14 @@ func TestBackupBackupAndHooksError(t *testing.T) {
 					"do-it": {
 						Recipe:   "r",
 						BackupTo: []string{"bogus"},
+						OnSuccess: &config.HookV1{
+							Shell:   "bash",
+							Command: "exit 44",
+						},
+						OnFailure: &config.HookV1{
+							Shell:   "bash",
+							Command: "exit 45",
+						},
 					},
 				},
 			},
@@ -515,14 +515,6 @@ func TestBackupOnlyHooksError(t *testing.T) {
 					Shell:   "bash",
 					Command: "exit 43",
 				},
-				OnSuccess: &config.HookV1{
-					Shell:   "bash",
-					Command: "exit 44",
-				},
-				OnFailure: &config.HookV1{
-					Shell:   "bash",
-					Command: "exit 45",
-				},
 			}},
 			MainConfig: config.MainConfig{
 				Destinations: map[string]config.DestinationConfigV1{
@@ -534,6 +526,14 @@ func TestBackupOnlyHooksError(t *testing.T) {
 					"do-it": {
 						Recipe:   "r",
 						BackupTo: []string{"bogus"},
+						OnSuccess: &config.HookV1{
+							Shell:   "bash",
+							Command: "exit 44",
+						},
+						OnFailure: &config.HookV1{
+							Shell:   "bash",
+							Command: "exit 45",
+						},
 					},
 				},
 			},
@@ -599,11 +599,9 @@ func TestBackupOnFailureCalledOnError(t *testing.T) {
 			err := svc.Backup(
 				config.Config{
 					Recipes: []config.RecipeManifestV1{{
-						Name:      "r",
-						Before:    test.before,
-						After:     test.after,
-						OnSuccess: test.onSuccess,
-						OnFailure: test.onFailure,
+						Name:   "r",
+						Before: test.before,
+						After:  test.after,
 					}},
 					MainConfig: config.MainConfig{
 						Destinations: map[string]config.DestinationConfigV1{
@@ -613,8 +611,10 @@ func TestBackupOnFailureCalledOnError(t *testing.T) {
 						},
 						Jobs: map[string]config.JobConfigV1{
 							"do-it": {
-								Recipe:   "r",
-								BackupTo: []string{"bogus"},
+								Recipe:    "r",
+								BackupTo:  []string{"bogus"},
+								OnSuccess: test.onSuccess,
+								OnFailure: test.onFailure,
 							},
 						},
 					},

--- a/internal/backup_test.go
+++ b/internal/backup_test.go
@@ -119,23 +119,21 @@ func TestBackupHooksSuccess(t *testing.T) {
 		config.Config{
 			Recipes: []config.RecipeManifestV1{{
 				Name: "r",
-				Hooks: config.HooksV1{
-					Before: &config.HookV1{
-						Shell:   "bash",
-						Command: fmt.Sprintf("echo before >> %s", hooksLog),
-					},
-					After: &config.HookV1{
-						Shell:   "bash",
-						Command: fmt.Sprintf("echo after >> %s", hooksLog),
-					},
-					OnSuccess: &config.HookV1{
-						Shell:   "bash",
-						Command: fmt.Sprintf("echo on-success >> %s", hooksLog),
-					},
-					OnFailure: &config.HookV1{
-						Shell:   "bash",
-						Command: fmt.Sprintf("echo on-failure >> %s", hooksLog),
-					},
+				Before: &config.HookV1{
+					Shell:   "bash",
+					Command: fmt.Sprintf("echo before >> %s", hooksLog),
+				},
+				After: &config.HookV1{
+					Shell:   "bash",
+					Command: fmt.Sprintf("echo after >> %s", hooksLog),
+				},
+				OnSuccess: &config.HookV1{
+					Shell:   "bash",
+					Command: fmt.Sprintf("echo on-success >> %s", hooksLog),
+				},
+				OnFailure: &config.HookV1{
+					Shell:   "bash",
+					Command: fmt.Sprintf("echo on-failure >> %s", hooksLog),
 				},
 			}},
 			MainConfig: config.MainConfig{
@@ -192,23 +190,21 @@ func TestBackupHooksFailure(t *testing.T) {
 		config.Config{
 			Recipes: []config.RecipeManifestV1{{
 				Name: "r",
-				Hooks: config.HooksV1{
-					Before: &config.HookV1{
-						Shell:   "bash",
-						Command: fmt.Sprintf("echo before >> %s", hooksLog),
-					},
-					After: &config.HookV1{
-						Shell:   "bash",
-						Command: fmt.Sprintf("echo after >> %s", hooksLog),
-					},
-					OnSuccess: &config.HookV1{
-						Shell:   "bash",
-						Command: fmt.Sprintf("echo on-success >> %s", hooksLog),
-					},
-					OnFailure: &config.HookV1{
-						Shell:   "bash",
-						Command: fmt.Sprintf("echo on-failure >> %s", hooksLog),
-					},
+				Before: &config.HookV1{
+					Shell:   "bash",
+					Command: fmt.Sprintf("echo before >> %s", hooksLog),
+				},
+				After: &config.HookV1{
+					Shell:   "bash",
+					Command: fmt.Sprintf("echo after >> %s", hooksLog),
+				},
+				OnSuccess: &config.HookV1{
+					Shell:   "bash",
+					Command: fmt.Sprintf("echo on-success >> %s", hooksLog),
+				},
+				OnFailure: &config.HookV1{
+					Shell:   "bash",
+					Command: fmt.Sprintf("echo on-failure >> %s", hooksLog),
 				},
 			}},
 			MainConfig: config.MainConfig{
@@ -253,11 +249,9 @@ func TestBackupBeforeHookError(t *testing.T) {
 		config.Config{
 			Recipes: []config.RecipeManifestV1{{
 				Name: "r",
-				Hooks: config.HooksV1{
-					Before: &config.HookV1{
-						Shell:   "bash",
-						Command: "exit 42",
-					},
+				Before: &config.HookV1{
+					Shell:   "bash",
+					Command: "exit 42",
 				},
 			}},
 			MainConfig: config.MainConfig{
@@ -293,15 +287,13 @@ func TestBackupRunAfterHookOnBeforeError(t *testing.T) {
 		config.Config{
 			Recipes: []config.RecipeManifestV1{{
 				Name: "r",
-				Hooks: config.HooksV1{
-					Before: &config.HookV1{
-						Shell:   "bash",
-						Command: "exit 42",
-					},
-					After: &config.HookV1{
-						Shell:   "bash",
-						Command: fmt.Sprintf("echo hello from after > %s", outPath),
-					},
+				Before: &config.HookV1{
+					Shell:   "bash",
+					Command: "exit 42",
+				},
+				After: &config.HookV1{
+					Shell:   "bash",
+					Command: fmt.Sprintf("echo hello from after > %s", outPath),
 				},
 			}},
 			MainConfig: config.MainConfig{
@@ -343,11 +335,9 @@ func TestBackupAfterHookError(t *testing.T) {
 		config.Config{
 			Recipes: []config.RecipeManifestV1{{
 				Name: "r",
-				Hooks: config.HooksV1{
-					After: &config.HookV1{
-						Shell:   "bash",
-						Command: "exit 42",
-					},
+				After: &config.HookV1{
+					Shell:   "bash",
+					Command: "exit 42",
 				},
 			}},
 			MainConfig: config.MainConfig{
@@ -387,11 +377,9 @@ func TestBackupOnSuccessHookError(t *testing.T) {
 		config.Config{
 			Recipes: []config.RecipeManifestV1{{
 				Name: "r",
-				Hooks: config.HooksV1{
-					OnSuccess: &config.HookV1{
-						Shell:   "bash",
-						Command: "exit 42",
-					},
+				OnSuccess: &config.HookV1{
+					Shell:   "bash",
+					Command: "exit 42",
 				},
 			}},
 			MainConfig: config.MainConfig{
@@ -431,11 +419,9 @@ func TestBackupOnFailureHookError(t *testing.T) {
 		config.Config{
 			Recipes: []config.RecipeManifestV1{{
 				Name: "r",
-				Hooks: config.HooksV1{
-					OnFailure: &config.HookV1{
-						Shell:   "bash",
-						Command: "exit 42",
-					},
+				OnFailure: &config.HookV1{
+					Shell:   "bash",
+					Command: "exit 42",
 				},
 			}},
 			MainConfig: config.MainConfig{
@@ -475,20 +461,18 @@ func TestBackupBackupAndHooksError(t *testing.T) {
 		config.Config{
 			Recipes: []config.RecipeManifestV1{{
 				Name: "r",
-				Hooks: config.HooksV1{
-					// We can't have Before fail otherwise, backup doesn't get performed
-					After: &config.HookV1{
-						Shell:   "bash",
-						Command: "exit 43",
-					},
-					OnSuccess: &config.HookV1{
-						Shell:   "bash",
-						Command: "exit 44",
-					},
-					OnFailure: &config.HookV1{
-						Shell:   "bash",
-						Command: "exit 45",
-					},
+				// We can't have Before fail otherwise, backup doesn't get performed
+				After: &config.HookV1{
+					Shell:   "bash",
+					Command: "exit 43",
+				},
+				OnSuccess: &config.HookV1{
+					Shell:   "bash",
+					Command: "exit 44",
+				},
+				OnFailure: &config.HookV1{
+					Shell:   "bash",
+					Command: "exit 45",
 				},
 			}},
 			MainConfig: config.MainConfig{
@@ -523,23 +507,21 @@ func TestBackupOnlyHooksError(t *testing.T) {
 		config.Config{
 			Recipes: []config.RecipeManifestV1{{
 				Name: "r",
-				Hooks: config.HooksV1{
-					Before: &config.HookV1{
-						Shell:   "bash",
-						Command: "exit 42",
-					},
-					After: &config.HookV1{
-						Shell:   "bash",
-						Command: "exit 43",
-					},
-					OnSuccess: &config.HookV1{
-						Shell:   "bash",
-						Command: "exit 44",
-					},
-					OnFailure: &config.HookV1{
-						Shell:   "bash",
-						Command: "exit 45",
-					},
+				Before: &config.HookV1{
+					Shell:   "bash",
+					Command: "exit 42",
+				},
+				After: &config.HookV1{
+					Shell:   "bash",
+					Command: "exit 43",
+				},
+				OnSuccess: &config.HookV1{
+					Shell:   "bash",
+					Command: "exit 44",
+				},
+				OnFailure: &config.HookV1{
+					Shell:   "bash",
+					Command: "exit 45",
 				},
 			}},
 			MainConfig: config.MainConfig{
@@ -568,34 +550,31 @@ func TestBackupOnlyHooksError(t *testing.T) {
 
 func TestBackupOnFailureCalledOnError(t *testing.T) {
 	tests := []struct {
-		name  string
-		hooks config.HooksV1
+		name      string
+		before    *config.HookV1
+		after     *config.HookV1
+		onSuccess *config.HookV1
+		onFailure *config.HookV1
 	}{
 		{
 			name: "before",
-			hooks: config.HooksV1{
-				Before: &config.HookV1{
-					Shell:   "bash",
-					Command: "exit 1",
-				},
+			before: &config.HookV1{
+				Shell:   "bash",
+				Command: "exit 1",
 			},
 		},
 		{
 			name: "after",
-			hooks: config.HooksV1{
-				After: &config.HookV1{
-					Shell:   "bash",
-					Command: "exit 1",
-				},
+			after: &config.HookV1{
+				Shell:   "bash",
+				Command: "exit 1",
 			},
 		},
 		{
 			name: "on-success",
-			hooks: config.HooksV1{
-				OnSuccess: &config.HookV1{
-					Shell:   "bash",
-					Command: "exit 1",
-				},
+			onSuccess: &config.HookV1{
+				Shell:   "bash",
+				Command: "exit 1",
 			},
 		},
 	}
@@ -612,7 +591,7 @@ func TestBackupOnFailureCalledOnError(t *testing.T) {
 
 			d := t.TempDir()
 			outFile := path.Join(d, "out.txt")
-			test.hooks.OnFailure = &config.HookV1{
+			test.onFailure = &config.HookV1{
 				Shell:   "bash",
 				Command: fmt.Sprintf("echo hello from on-failure > %s", outFile),
 			}
@@ -620,8 +599,11 @@ func TestBackupOnFailureCalledOnError(t *testing.T) {
 			err := svc.Backup(
 				config.Config{
 					Recipes: []config.RecipeManifestV1{{
-						Name:  "r",
-						Hooks: test.hooks,
+						Name:      "r",
+						Before:    test.before,
+						After:     test.after,
+						OnSuccess: test.onSuccess,
+						OnFailure: test.onFailure,
 					}},
 					MainConfig: config.MainConfig{
 						Destinations: map[string]config.DestinationConfigV1{

--- a/internal/config/hook.go
+++ b/internal/config/hook.go
@@ -1,0 +1,26 @@
+package config
+
+import "github.com/santhosh-tekuri/jsonschema/v6"
+
+const hookSchemaUrl = "standard-backups://hook.schema.json"
+
+var (
+	hookSchemaDoc = map[string]any{
+		"type":     "object",
+		"required": []any{"shell", "command"},
+		"properties": map[string]any{
+			"shell":   map[string]any{"enum": []any{"bash", "sh"}},
+			"command": map[string]any{"type": "string"},
+		},
+	}
+	hookSchemaRef = map[string]any{"$ref": hookSchemaUrl}
+)
+
+func addHookSchema(compiler *jsonschema.Compiler) error {
+	return compiler.AddResource(hookSchemaUrl, hookSchemaDoc)
+}
+
+type HookV1 struct {
+	Shell   string `mapstructure:"shell"`
+	Command string `mapstructure:"command"`
+}

--- a/internal/config/main_config.go
+++ b/internal/config/main_config.go
@@ -20,8 +20,10 @@ type (
 		Options map[string]any
 	}
 	JobConfigV1 struct {
-		Recipe   string
-		BackupTo []string `mapstructure:"backup-to"`
+		Recipe    string
+		BackupTo  []string `mapstructure:"backup-to"`
+		OnSuccess *HookV1  `mapstructure:"on-success"`
+		OnFailure *HookV1  `mapstructure:"on-failure"`
 	}
 	SecretConfigV1 struct {
 		FromFile string `mapstructure:"from-file"`
@@ -94,6 +96,8 @@ func makeMainConfigSchema(
 									"type": "string",
 								},
 							},
+							"on-success": hookSchemaRef,
+							"on-failure": hookSchemaRef,
 						},
 					},
 				},
@@ -116,6 +120,10 @@ func makeMainConfigSchema(
 			},
 		},
 	})
+	if err != nil {
+		return nil, err
+	}
+	err = addHookSchema(compiler)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/config/recipe_manifest.go
+++ b/internal/config/recipe_manifest.go
@@ -34,15 +34,10 @@ var (
 				},
 				"minItems": 1,
 			},
-			"hooks": map[string]any{
-				"type": "object",
-				"properties": map[string]any{
-					"before":     hookSchemaRef,
-					"after":      hookSchemaRef,
-					"on-success": hookSchemaRef,
-					"on-failure": hookSchemaRef,
-				},
-			},
+			"before":     hookSchemaRef,
+			"after":      hookSchemaRef,
+			"on-success": hookSchemaRef,
+			"on-failure": hookSchemaRef,
 		},
 	}
 	recipeManifestV1Schema jsonschema.Schema
@@ -73,20 +68,16 @@ func init() {
 	recipeManifestV1Schema = *res
 }
 
-type HooksV1 struct {
-	Before    *HookV1 `mapstructure:"before"`
-	After     *HookV1 `mapstructure:"after"`
-	OnSuccess *HookV1 `mapstructure:"on-success"`
-	OnFailure *HookV1 `mapstructure:"on-failure"`
-}
-
 type RecipeManifestV1 struct {
 	path        string
 	Version     int      `mapstructure:"version"`
 	Name        string   `mapstructure:"name"`
 	Description string   `mapstructure:"description"`
 	Paths       []string `mapstructure:"paths"`
-	Hooks       HooksV1  `mapstructure:"hooks"`
+	Before      *HookV1  `mapstructure:"before"`
+	After       *HookV1  `mapstructure:"after"`
+	OnSuccess   *HookV1  `mapstructure:"on-success"`
+	OnFailure   *HookV1  `mapstructure:"on-failure"`
 }
 
 func LoadRecipeManifests(dirs []string) ([]RecipeManifestV1, error) {

--- a/internal/config/recipe_manifest.go
+++ b/internal/config/recipe_manifest.go
@@ -37,20 +37,10 @@ var (
 			"hooks": map[string]any{
 				"type": "object",
 				"properties": map[string]any{
-					"before":     map[string]any{"$ref": "#/$defs/hook"},
-					"after":      map[string]any{"$ref": "#/$defs/hook"},
-					"on-success": map[string]any{"$ref": "#/$defs/hook"},
-					"on-failure": map[string]any{"$ref": "#/$defs/hook"},
-				},
-			},
-		},
-		"$defs": map[string]any{
-			"hook": map[string]any{
-				"type":     "object",
-				"required": []any{"shell", "command"},
-				"properties": map[string]any{
-					"shell":   map[string]any{"enum": []any{"bash", "sh"}},
-					"command": map[string]any{"type": "string"},
+					"before":     hookSchemaRef,
+					"after":      hookSchemaRef,
+					"on-success": hookSchemaRef,
+					"on-failure": hookSchemaRef,
 				},
 			},
 		},
@@ -61,6 +51,10 @@ var (
 func loadRecipeManifestV1Schema() (*jsonschema.Schema, error) {
 	compiler := jsonschema.NewCompiler()
 	err := compiler.AddResource(recipeManifestV1SchemaUrl, _recipeManifestV1Schema)
+	if err != nil {
+		return nil, err
+	}
+	err = addHookSchema(compiler)
 	if err != nil {
 		return nil, err
 	}
@@ -77,11 +71,6 @@ func init() {
 		log.Panicf("[internal error] failed to load recipe manifest v1 schema: %v", err)
 	}
 	recipeManifestV1Schema = *res
-}
-
-type HookV1 struct {
-	Shell   string `mapstructure:"shell"`
-	Command string `mapstructure:"command"`
 }
 
 type HooksV1 struct {

--- a/internal/config/recipe_manifest.go
+++ b/internal/config/recipe_manifest.go
@@ -34,10 +34,8 @@ var (
 				},
 				"minItems": 1,
 			},
-			"before":     hookSchemaRef,
-			"after":      hookSchemaRef,
-			"on-success": hookSchemaRef,
-			"on-failure": hookSchemaRef,
+			"before": hookSchemaRef,
+			"after":  hookSchemaRef,
 		},
 	}
 	recipeManifestV1Schema jsonschema.Schema
@@ -76,8 +74,6 @@ type RecipeManifestV1 struct {
 	Paths       []string `mapstructure:"paths"`
 	Before      *HookV1  `mapstructure:"before"`
 	After       *HookV1  `mapstructure:"after"`
-	OnSuccess   *HookV1  `mapstructure:"on-success"`
-	OnFailure   *HookV1  `mapstructure:"on-failure"`
 }
 
 func LoadRecipeManifests(dirs []string) ([]RecipeManifestV1, error) {

--- a/internal/config/recipe_manifest_test.go
+++ b/internal/config/recipe_manifest_test.go
@@ -53,14 +53,6 @@ func TestLoadRecipeManifestsSingleFile(t *testing.T) {
 					Shell:   "sh",
 					Command: "echo after",
 				},
-				OnSuccess: &HookV1{
-					Shell:   "bash",
-					Command: "echo success",
-				},
-				OnFailure: &HookV1{
-					Shell:   "bash",
-					Command: "echo failure",
-				},
 			},
 		}, manifests)
 	}
@@ -81,12 +73,6 @@ func TestLoadRecipeManifestsMultipleFiles(t *testing.T) {
 			after:
 				shell: sh
 				command: echo after 1
-			on-success:
-				shell: bash
-				command: echo success 1
-			on-failure:
-				shell: bash
-				command: echo failure 1
 		`)),
 		0o644)
 	if !assert.NoError(t, err) {
@@ -106,12 +92,6 @@ func TestLoadRecipeManifestsMultipleFiles(t *testing.T) {
 			after:
 				shell: sh
 				command: echo after 2
-			on-success:
-				shell: bash
-				command: echo success 2
-			on-failure:
-				shell: bash
-				command: echo failure 2
 		`)),
 		0o644)
 	if !assert.NoError(t, err) {
@@ -134,14 +114,6 @@ func TestLoadRecipeManifestsMultipleFiles(t *testing.T) {
 					Shell:   "sh",
 					Command: "echo after 1",
 				},
-				OnSuccess: &HookV1{
-					Shell:   "bash",
-					Command: "echo success 1",
-				},
-				OnFailure: &HookV1{
-					Shell:   "bash",
-					Command: "echo failure 1",
-				},
 			},
 			{
 				path:        p2,
@@ -156,14 +128,6 @@ func TestLoadRecipeManifestsMultipleFiles(t *testing.T) {
 				After: &HookV1{
 					Shell:   "sh",
 					Command: "echo after 2",
-				},
-				OnSuccess: &HookV1{
-					Shell:   "bash",
-					Command: "echo success 2",
-				},
-				OnFailure: &HookV1{
-					Shell:   "bash",
-					Command: "echo failure 2",
 				},
 			},
 		}, manifests)
@@ -308,7 +272,7 @@ func TestLoadRecipeManifestsInvalidEmptyPaths(t *testing.T) {
 }
 
 func TestLoadRecipeManifestsInvalidHooks(t *testing.T) {
-	for _, hook := range []string{"before", "after", "on-success", "on-failure"} {
+	for _, hook := range []string{"before", "after"} {
 		t.Run(fmt.Sprintf("%s/bad_shell", hook), func(t *testing.T) {
 			d := t.TempDir()
 			p := path.Join(d, "app.yaml")

--- a/internal/config/recipe_manifest_test.go
+++ b/internal/config/recipe_manifest_test.go
@@ -19,19 +19,18 @@ func TestLoadRecipeManifestsSingleFile(t *testing.T) {
 			name: example 1
 			description: the first example
 			paths: [/app/to/backup/1]
-			hooks:
-				before:
-					shell: bash
-					command: echo before
-				after:
-					shell: sh
-					command: echo after
-				on-success:
-					shell: bash
-					command: echo success
-				on-failure:
-					shell: bash
-					command: echo failure
+			before:
+				shell: bash
+				command: echo before
+			after:
+				shell: sh
+				command: echo after
+			on-success:
+				shell: bash
+				command: echo success
+			on-failure:
+				shell: bash
+				command: echo failure
 		`)),
 		0o644)
 	if !assert.NoError(t, err) {
@@ -46,23 +45,21 @@ func TestLoadRecipeManifestsSingleFile(t *testing.T) {
 				Name:        "example 1",
 				Description: "the first example",
 				Paths:       []string{"/app/to/backup/1"},
-				Hooks: HooksV1{
-					Before: &HookV1{
-						Shell:   "bash",
-						Command: "echo before",
-					},
-					After: &HookV1{
-						Shell:   "sh",
-						Command: "echo after",
-					},
-					OnSuccess: &HookV1{
-						Shell:   "bash",
-						Command: "echo success",
-					},
-					OnFailure: &HookV1{
-						Shell:   "bash",
-						Command: "echo failure",
-					},
+				Before: &HookV1{
+					Shell:   "bash",
+					Command: "echo before",
+				},
+				After: &HookV1{
+					Shell:   "sh",
+					Command: "echo after",
+				},
+				OnSuccess: &HookV1{
+					Shell:   "bash",
+					Command: "echo success",
+				},
+				OnFailure: &HookV1{
+					Shell:   "bash",
+					Command: "echo failure",
 				},
 			},
 		}, manifests)
@@ -78,19 +75,18 @@ func TestLoadRecipeManifestsMultipleFiles(t *testing.T) {
 			name: app1
 			description: the app1
 			paths: [/app/to/backup/1]
-			hooks:
-				before:
-					shell: bash
-					command: echo before 1
-				after:
-					shell: sh
-					command: echo after 1
-				on-success:
-					shell: bash
-					command: echo success 1
-				on-failure:
-					shell: bash
-					command: echo failure 1
+			before:
+				shell: bash
+				command: echo before 1
+			after:
+				shell: sh
+				command: echo after 1
+			on-success:
+				shell: bash
+				command: echo success 1
+			on-failure:
+				shell: bash
+				command: echo failure 1
 		`)),
 		0o644)
 	if !assert.NoError(t, err) {
@@ -104,19 +100,18 @@ func TestLoadRecipeManifestsMultipleFiles(t *testing.T) {
 			name: app2
 			description: the app2
 			paths: [/app/to/backup/2]
-			hooks:
-				before:
-					shell: bash
-					command: echo before 2
-				after:
-					shell: sh
-					command: echo after 2
-				on-success:
-					shell: bash
-					command: echo success 2
-				on-failure:
-					shell: bash
-					command: echo failure 2
+			before:
+				shell: bash
+				command: echo before 2
+			after:
+				shell: sh
+				command: echo after 2
+			on-success:
+				shell: bash
+				command: echo success 2
+			on-failure:
+				shell: bash
+				command: echo failure 2
 		`)),
 		0o644)
 	if !assert.NoError(t, err) {
@@ -131,23 +126,21 @@ func TestLoadRecipeManifestsMultipleFiles(t *testing.T) {
 				Name:        "app1",
 				Description: "the app1",
 				Paths:       []string{"/app/to/backup/1"},
-				Hooks: HooksV1{
-					Before: &HookV1{
-						Shell:   "bash",
-						Command: "echo before 1",
-					},
-					After: &HookV1{
-						Shell:   "sh",
-						Command: "echo after 1",
-					},
-					OnSuccess: &HookV1{
-						Shell:   "bash",
-						Command: "echo success 1",
-					},
-					OnFailure: &HookV1{
-						Shell:   "bash",
-						Command: "echo failure 1",
-					},
+				Before: &HookV1{
+					Shell:   "bash",
+					Command: "echo before 1",
+				},
+				After: &HookV1{
+					Shell:   "sh",
+					Command: "echo after 1",
+				},
+				OnSuccess: &HookV1{
+					Shell:   "bash",
+					Command: "echo success 1",
+				},
+				OnFailure: &HookV1{
+					Shell:   "bash",
+					Command: "echo failure 1",
 				},
 			},
 			{
@@ -156,23 +149,21 @@ func TestLoadRecipeManifestsMultipleFiles(t *testing.T) {
 				Name:        "app2",
 				Description: "the app2",
 				Paths:       []string{"/app/to/backup/2"},
-				Hooks: HooksV1{
-					Before: &HookV1{
-						Shell:   "bash",
-						Command: "echo before 2",
-					},
-					After: &HookV1{
-						Shell:   "sh",
-						Command: "echo after 2",
-					},
-					OnSuccess: &HookV1{
-						Shell:   "bash",
-						Command: "echo success 2",
-					},
-					OnFailure: &HookV1{
-						Shell:   "bash",
-						Command: "echo failure 2",
-					},
+				Before: &HookV1{
+					Shell:   "bash",
+					Command: "echo before 2",
+				},
+				After: &HookV1{
+					Shell:   "sh",
+					Command: "echo after 2",
+				},
+				OnSuccess: &HookV1{
+					Shell:   "bash",
+					Command: "echo success 2",
+				},
+				OnFailure: &HookV1{
+					Shell:   "bash",
+					Command: "echo failure 2",
 				},
 			},
 		}, manifests)
@@ -328,10 +319,9 @@ func TestLoadRecipeManifestsInvalidHooks(t *testing.T) {
 					name: app
 					description: app description
 					paths: [bogus]
-					hooks:
-						%s:
-							shell: nope
-							command: echo test
+					%s:
+						shell: nope
+						command: echo test
 				`, hook))),
 				0o644,
 			)
@@ -343,7 +333,7 @@ func TestLoadRecipeManifestsInvalidHooks(t *testing.T) {
 				assert.Equal(t,
 					testutils.Dedent(fmt.Sprintf(`
 						recipe manifest %s is invalid: jsonschema validation failed with 'standard-backups://recipe-manifest-v1.schema.json#'
-						- at '/hooks/%s/shell': value must be one of 'bash', 'sh'
+						- at '/%s/shell': value must be one of 'bash', 'sh'
 					`, p, hook)),
 					err.Error(),
 				)
@@ -359,9 +349,8 @@ func TestLoadRecipeManifestsInvalidHooks(t *testing.T) {
 					name: app
 					description: app description
 					paths: [bogus]
-					hooks:
-						%s:
-							command: echo test
+					%s:
+						command: echo test
 				`, hook))),
 				0o644,
 			)
@@ -373,7 +362,7 @@ func TestLoadRecipeManifestsInvalidHooks(t *testing.T) {
 				assert.Equal(t,
 					testutils.Dedent(fmt.Sprintf(`
 						recipe manifest %s is invalid: jsonschema validation failed with 'standard-backups://recipe-manifest-v1.schema.json#'
-						- at '/hooks/%s': missing property 'shell'
+						- at '/%s': missing property 'shell'
 					`, p, hook)),
 					err.Error(),
 				)
@@ -389,9 +378,8 @@ func TestLoadRecipeManifestsInvalidHooks(t *testing.T) {
 					name: app
 					description: app description
 					paths: [bogus]
-					hooks:
-						%s:
-							shell: sh
+					%s:
+						shell: sh
 				`, hook))),
 				0o644,
 			)
@@ -403,7 +391,7 @@ func TestLoadRecipeManifestsInvalidHooks(t *testing.T) {
 				assert.Equal(t,
 					testutils.Dedent(fmt.Sprintf(`
 						recipe manifest %s is invalid: jsonschema validation failed with 'standard-backups://recipe-manifest-v1.schema.json#'
-						- at '/hooks/%s': missing property 'command'
+						- at '/%s': missing property 'command'
 					`, p, hook)),
 					err.Error(),
 				)

--- a/internal/config/recipe_manifest_test.go
+++ b/internal/config/recipe_manifest_test.go
@@ -25,12 +25,6 @@ func TestLoadRecipeManifestsSingleFile(t *testing.T) {
 			after:
 				shell: sh
 				command: echo after
-			on-success:
-				shell: bash
-				command: echo success
-			on-failure:
-				shell: bash
-				command: echo failure
 		`)),
 		0o644)
 	if !assert.NoError(t, err) {


### PR DESCRIPTION
Fixes #46 

This will allow admins to configure notifications from the main config. This makes a lot more sense then having them on the job since recipes shouldn't care about success or failure. They can handle everything with the `after` hook.