### PR TITLE
fix(config): relax manifest discovery to allow symlinks

### DIFF
--- a/internal/config/backend_manifest.go
+++ b/internal/config/backend_manifest.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"log/slog"
 	"os"
 	"path"
 	"strings"
@@ -76,13 +77,16 @@ func LoadBackendManifests(dirs []string) ([]BackendManifestV1, error) {
 		}
 
 		for _, entry := range entries {
-			if entry.Type().IsRegular() && strings.HasSuffix(entry.Name(), ".yaml") {
-				fullPath := path.Join(dir, entry.Name())
+			fullPath := path.Join(dir, entry.Name())
+			if strings.HasSuffix(entry.Name(), ".yaml") {
+				slog.Debug("loading backend", slog.String("path", fullPath))
 				backendManifest, err := loadBackendManifest(fullPath)
 				if err != nil {
 					return nil, err
 				}
 				manifests = append(manifests, *backendManifest)
+			} else {
+				slog.Debug("skipped while loading backends", slog.String("path", fullPath))
 			}
 		}
 	}

--- a/internal/config/recipe_manifest.go
+++ b/internal/config/recipe_manifest.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"log/slog"
 	"os"
 	"path"
 	"strings"
@@ -88,13 +89,16 @@ func LoadRecipeManifests(dirs []string) ([]RecipeManifestV1, error) {
 		}
 
 		for _, entry := range entries {
-			if entry.Type().IsRegular() && strings.HasSuffix(entry.Name(), ".yaml") {
-				fullPath := path.Join(dir, entry.Name())
+			fullPath := path.Join(dir, entry.Name())
+			if strings.HasSuffix(entry.Name(), ".yaml") {
+				slog.Debug("loading recipe", slog.String("path", fullPath))
 				manifest, err := loadRecipeManifest(fullPath)
 				if err != nil {
 					return nil, err
 				}
 				manifests = append(manifests, *manifest)
+			} else {
+				slog.Debug("skipped while loading recipes", slog.String("path", fullPath))
 			}
 		}
 	}


### PR DESCRIPTION
The code was explicitly checking for normal files and not symlinks. When the files happen to be symlinks, we skipped them.

This removes the file check and just relies on os.ReadFile to crash if we give it a directory or some nonesense like it.